### PR TITLE
修复一处bug

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -43,7 +43,7 @@ export function loadPlugins(fileUri: vscode.Uri) {
     }
     else{
         var uris = fileUri.fsPath;
-        terminal.sendText('lxl load ' + uris);
+        terminal.sendText('lxl load ' + '"' + uris + '"');
         vscode.window.showInformationMessage('插件 ' + uris + ' 已加载');
     }
 }
@@ -58,7 +58,7 @@ export function reloadPlugins(fileUri: vscode.Uri) {
     }
     else{
         var uris = path.basename(fileUri.fsPath);
-        terminal.sendText('lxl reload ' + uris);
+        terminal.sendText('lxl reload ' + '"' + uris + '"');
         vscode.window.showInformationMessage('插件 ' + uris + ' 已重载');
     }
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -26,10 +26,10 @@ export class LuaRunner implements vscode.Disposable {
             var uris = fileUri.fsPath;
             if (this.uriList.includes(uris)) {
                 var fileName = path.basename(uris);
-                this.terminal.sendText('lxl reload ' +fileName);
+                this.terminal.sendText('lxl reload ' + '"' + fileName + '"');
                 vscode.window.showInformationMessage('Lua '+fileName+' 已重载');
             } else {
-                this.terminal.sendText('lxl load ' + uris);
+                this.terminal.sendText('lxl load ' + '"' + uris + '"');
                 vscode.window.showInformationMessage('Lua ' + uris + ' 已加载');
                 this.uriList.push(uris);
             }


### PR DESCRIPTION
在程序尝试加载的脚本的目录或脚本名字中有空格时，lxl可能无法解析此插件给出的命令。
如图：
![image](https://user-images.githubusercontent.com/67588574/150247348-be3f4999-177b-43cf-90fa-8bf491e4d9a8.png)
因此，在文件目录或文件名前后加上引号可以解决此类问题。