### PR TITLE
Fix wrong path in nodejs when using reload

### DIFF
--- a/src/terminal/TerminalHelper.ts
+++ b/src/terminal/TerminalHelper.ts
@@ -8,7 +8,7 @@ import * as vscode from "vscode";
 import "./TerminalConst";
 import * as path from "path";
 import { CommandType, TerminalKeys, TerminalState } from "./TerminalConst";
-import { getLiteLoaderpath } from "../utils/FileUtils";
+import { getLiteLoaderpath, getFilePath } from "../utils/FileUtils";
 // import { getBDSCwdPath, getBDSPath } from "../utils/WorkspaceUtil";
 export class TerminalHelper {
 	static terminal: vscode.Terminal | undefined;
@@ -44,16 +44,22 @@ export class TerminalHelper {
 				this.stopConsole();
 			}),
 			vscode.commands.registerCommand("extension.llseaids.load", (uri) => {
-				const _path = uri.fsPath;
-				this.managePlugin(CommandType.LOAD, _path);
+				this.managePlugin(
+					CommandType.LOAD, 
+					getFilePath(uri.fsPath, false)
+				);
 			}),
 			vscode.commands.registerCommand("extension.llseaids.unload", (uri) => {
-				const _path = path.parse(uri.fsPath).base;
-				this.managePlugin(CommandType.UNLOAD, _path);
+				this.managePlugin(
+					CommandType.UNLOAD, 
+					getFilePath(uri.fsPath, true)
+				);
 			}),
 			vscode.commands.registerCommand("extension.llseaids.reload", (uri) => {
-				const _path = path.parse(uri.fsPath).base;
-				this.managePlugin(CommandType.RELOAD, _path);
+				this.managePlugin(
+					CommandType.RELOAD, 
+					getFilePath(uri.fsPath, true)
+				);
 			})
 		);
 	}

--- a/src/utils/FileUtils.ts
+++ b/src/utils/FileUtils.ts
@@ -15,9 +15,8 @@ import StreamZip = require("node-stream-zip");
 import * as vscode from "vscode";
 import { randomUUID } from "crypto";
 import { rejects } from "assert";
-import { resolve } from "path";
+import * as path from "path";
 import { ConfigScope, Sections } from "../data/ConfigScope";
-import path = require("path");
 
 /**
  * 同步查找文件匹配


### PR DESCRIPTION
For example there is a nodejs plugin called TestPlugin under `plugins/nodejs/test_plugin`.

In past versions, using the button `load`, `unload`, would use the command:
`ll load "plugins/nodejs/test_plugin/index.js"` and `ll unload "index.js"` 
not 
`ll load "plugins/nodejs/test_plugin"` and `ll unload "TestPlugin"`

This PR, in which the user uses `load`,`unload`,`reload` at the **nodejs entry file**  (such as "index.js" or "app.js"), will convert the path to the supported way in LL for hot reloading nodejs plugins

Here's the console output after the fix, with a TestQuickJSPlugin.js added under plugin for cross-reference

```
// use reload in plugins\nodejs\test_plugin\index.js
ll reload "TestPlugin"
14:48:44 INFO [LiteLoader] TestPlugin unloaded.

node hello
14:48:44 INFO [LiteLoader] Node.js 插件 <TestPlugin> 已加载。
14:48:44 INFO [Server] 插件 <TestPlugin> 已重载。
14:48:44 INFO [LiteLoader] NodeJs plugin TestPlugin exited.

// use unload in plugins\nodejs\test_plugin\index.js
ll unload "TestPlugin"
14:48:49 INFO [LiteLoader] TestPlugin unloaded.
14:48:49 INFO [Server] <TestPlugin> 插件已卸载
14:48:49 INFO [LiteLoader] NodeJs plugin TestPlugin exited.

// use load in plugins\nodejs\test_plugin\index.js
ll load "E:\bedrock-server\plugins\nodejs\test_plugin"

quickjs hello
14:48:50 INFO [LiteLoader] Node.js 插件 <TestPlugin> 已加载。
14:48:50 INFO [Server] 插件 <E:\bedrock-server\plugins\nodejs\test_plugin> 已加载

// use load in plugins\TestQuickJSPlugin.js
ll load "E:\bedrock-server\plugins\TestQuickJSPlugin.js"
14:52:22 INFO [TestQuickJSPlugin] quickjs hello
14:52:22 INFO [LiteLoader] Js 插件 <TestQuickJSPlugin> 已加载。
14:52:22 INFO [Server] 插件 <E:\bedrock-server\plugins\TestQuickJSPlugin.js> 已加载

// use unload in plugins\TestQuickJSPlugin.js
ll unload "TestQuickJSPlugin.js"
14:52:33 INFO [LiteLoader] TestQuickJSPlugin unloaded.
14:52:33 INFO [Server] <TestQuickJSPlugin.js> 插件已卸载
```